### PR TITLE
README.md installation example does not correctly parse browser_download_url.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Please read [Apple](https://support.apple.com/en-us/HT208544)'s external GPU doc
 ## Installation
 **set-eGPU.sh** auto-manages itself and provides multiple installation and uninstallation options. Once the **pre-requisites** are satisfied, install the script by running the following in **Terminal**:
 ```bash
-curl -q -s "https://api.github.com/repos/mayankk2308/set-egpu/releases/latest" | grep '"browser_download_url":' | sed -E 's/.*"([^"]+)".*/\1/' | xargs curl -L -s -0 > set-eGPU.sh && chmod +x set-eGPU.sh && ./set-eGPU.sh && rm set-eGPU.sh
+curl -q -s "https://api.github.com/repos/mayankk2308/set-egpu/releases/latest" | grep '"browser_download_url":' | sed -E 's/.*"browser_download_url":[ \t]*"([^"]+)".*/\1/' | xargs curl -L -s -0 > set-eGPU.sh && chmod +x set-eGPU.sh && ./set-eGPU.sh && rm set-eGPU.sh
 ```
 
 For future use, only the following will be required:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Please read [Apple](https://support.apple.com/en-us/HT208544)'s external GPU doc
 ## Installation
 **set-eGPU.sh** auto-manages itself and provides multiple installation and uninstallation options. Once the **pre-requisites** are satisfied, install the script by running the following in **Terminal**:
 ```bash
-curl -s "https://api.github.com/repos/mayankk2308/set-egpu/releases/latest" | grep '"browser_download_url":' | sed -E 's/.*"([^"]+)".*/\1/' | xargs curl -L -s -0 > set-eGPU.sh && chmod +x set-eGPU.sh && ./set-eGPU.sh && rm set-eGPU.sh
+curl -q -s "https://api.github.com/repos/mayankk2308/set-egpu/releases/latest" | grep '"browser_download_url":' | sed -E 's/.*"([^"]+)".*/\1/' | xargs curl -L -s -0 > set-eGPU.sh && chmod +x set-eGPU.sh && ./set-eGPU.sh && rm set-eGPU.sh
 ```
 
 For future use, only the following will be required:


### PR DESCRIPTION
# Pull Request

### Problem(s)
The contents of the ~/.curlrc file may specify a user-agent which causes the server to return a single-line JSON response, as opposed to a multi-line response.

Specifically, specifying the following user-agent will exhibit the problem (single-line response):

```
# Disguise as IE 9 on Windows 7.
user-agent = "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)"
```

### Changes
Add the '-q' option to curl to explicitly ignore the ~/.curlrc file.  Fix up the regex for finding browser_download_url to handle both multiline and single-line responses from the server.
